### PR TITLE
Add logging and better handling of error responses from web api

### DIFF
--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -1,7 +1,7 @@
 name: Label pull requests
 on:
   pull_request:
-    types: [opened]
+    types: [opened, synchronize]
 jobs:
   pr-labeler:
     runs-on: ubuntu-latest

--- a/src/pages/Geocoding.jsx
+++ b/src/pages/Geocoding.jsx
@@ -79,7 +79,7 @@ export default function Geocoding() {
           </div>
           <div className="px-4 py-5 bg-white sm:grid sm:grid-cols-3 sm:gap-4 sm:px-6">
             <dt className="font-medium text-gray-500">Average match score</dt>
-            <dd className="mt-1 text-gray-900 sm:mt-0 sm:col-span-2">{stats.averageScore}</dd>
+            <dd className="mt-1 text-gray-900 sm:mt-0 sm:col-span-2">{stats.averageScore || ''}</dd>
           </div>
           <div className="px-4 py-5 bg-gray-50 sm:grid sm:grid-cols-3 sm:gap-4 sm:px-6">
             <dt className="font-medium text-gray-500">Time elapsed</dt>

--- a/src/services/geocode.js
+++ b/src/services/geocode.js
@@ -131,7 +131,12 @@ export const geocode = async (event, { filePath, fields, apiKey, wkid = 26912 })
         }).json();
       } catch (error) {
         log.error(`Error geocoding ${street} ${zone}: ${error}`);
-        response = JSON.parse(error.response.body);
+
+        try {
+          response = JSON.parse(error.response.body);
+        } catch (error) {
+          response = { error: error.message };
+        }
 
         failures += 1;
       }


### PR DESCRIPTION
Closes #70

This PR adds some logging to the geocoding process and better handles non-json-parse-able responses from the web api.

After these changes I was able to successfully complete the geocoding using the test data in #70.

Here's an example of the error that was causing the geocoding process to hang:

![image](https://user-images.githubusercontent.com/1326248/140586660-80a0d5ca-13eb-46ee-86b6-4ead933d26d9.png)
