### PR TITLE
Correct issue with CSV parsing of data with trailing whitespace

### DIFF
--- a/src/components/FieldLinker.jsx
+++ b/src/components/FieldLinker.jsx
@@ -31,8 +31,10 @@ const FieldLinker = () => {
           value={geocodeContext.data.street}
         >
           <option>please select a field</option>
-          {geocodeContext.data.fieldsFromFile.map((field) => (
-            <option key={field}>{field}</option>
+          {geocodeContext.data.fieldsFromFile.map((field, index) => (
+            <option key={index + field} value={field}>
+              {field}
+            </option>
           ))}
         </select>
         <label htmlFor="zone">Zone Field</label>
@@ -42,8 +44,10 @@ const FieldLinker = () => {
           value={geocodeContext.data.zone}
         >
           <option>please select a field</option>
-          {geocodeContext.data.fieldsFromFile.map((field) => (
-            <option key={field}>{field}</option>
+          {geocodeContext.data.fieldsFromFile.map((field, index) => (
+            <option key={index + field} value={field}>
+              {field}
+            </option>
           ))}
         </select>
       </form>

--- a/src/components/GeocodeContext.js
+++ b/src/components/GeocodeContext.js
@@ -1,4 +1,3 @@
-import { data } from 'autoprefixer';
 import { createContext, useContext } from 'react';
 import { useImmerReducer } from 'use-immer';
 


### PR DESCRIPTION
# Thanks for contributing

## Identify the issue referencing the feature or bug

closes #123

## Description of the Change

Adding the field name as a child of an option removed the trailing whitespace. Using the value attribute preserves the name exactly.