### PR TITLE
Fix application crash involving request timeouts

### DIFF
--- a/src/services/geocode.js
+++ b/src/services/geocode.js
@@ -46,7 +46,7 @@ export const cancelGeocode = (status = 'cancelled') => {
   cancelled = status;
 };
 
-const timeout = { request: 5000 };
+const timeout = { request: 10000 };
 
 export const checkApiKey = async (apiKey) => {
   log.info(`Checking API key: ${apiKey}`);
@@ -171,7 +171,7 @@ export const geocode = async (event, { filePath, fields, apiKey, wkid = 26912, s
           body: response.body,
         };
       } catch (error) {
-        log.error(`Error geocoding ${street} ${zone}: ${error}`);
+        log.error(`Error geocoding street [${street}] zone [${zone}]: ${error}`);
 
         try {
           response = JSON.parse(error.response.body);

--- a/src/services/geocode.js
+++ b/src/services/geocode.js
@@ -181,7 +181,7 @@ export const geocode = async (event, { filePath, fields, apiKey, wkid = 26912, s
 
         lastRequest.request.url = error?.request?.requestUrl.toString();
         lastRequest.response = {
-          status: error.response.statusCode,
+          status: error.response?.statusCode ?? 'response is undefined', // response is undefined when got throws
           body: response?.error ?? response?.message,
         };
 


### PR DESCRIPTION
## Identify the issue referencing the feature or bug

Fixes #122

## Description of the Change

* Bump dependencies including React v18 and Electron v18.
* Add mock server for testing.
* Fix bug that was causing timed out requests (and perhaps other reasons for `got` to throw) to crash the app.

**Note: Once this PR is approved and merged, someone needs to upload the new debug symbols to Sentry.**